### PR TITLE
chore: update image tag 95b7360

### DIFF
--- a/tenants/webest/values.yaml
+++ b/tenants/webest/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: dolldot/webest
-  tag: 377c158
+  tag: 95b7360
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
This PR updates the manifest with the new image tag: 95b7360